### PR TITLE
feat(notifications): SMS notification processor (TASK-035)

### DIFF
--- a/.claude/DESIGN_STATE.yaml
+++ b/.claude/DESIGN_STATE.yaml
@@ -9,7 +9,7 @@
 # ============================================================
 
 meta:
-  version: "3.2.0"
+  version: "3.3.0"
   updated_at: "2026-01-16"
   updated_by: "A Session"
   branch: "main"
@@ -572,11 +572,18 @@ current_iterations:
 
       - id: "TASK-035"
         title: "Backend: SMS notification processor"
-        status: "pending"
+        status: "completed"
         priority: "P0"
         handoff: "HO-035-sms-processor.yaml"
         depends_on: ["TASK-034"]
         description: "Add SMS channel to notification queue processor"
+        skeleton_files:
+          - "apps/backend/src/modules/notifications/notification.processor.ts"
+          - "apps/backend/src/modules/notifications/notification.module.ts"
+          - "apps/backend/src/modules/notifications/notification.service.ts"
+        skeleton_version: "3.2.1"
+        review_verdict: "pass"
+        completed_at: "2026-01-16"
 
       - id: "TASK-036"
         title: "Backend: Phone number verification"

--- a/.claude/handoffs/iter-010/HO-035-sms-processor.yaml
+++ b/.claude/handoffs/iter-010/HO-035-sms-processor.yaml
@@ -1,14 +1,15 @@
 # ============================================================
 # Handoff Document: SMS Notification Processor
 # @task TASK-035
-# @design_state_version 3.0.0
+# @design_state_version 3.0.1
 # ============================================================
 
 handoff_id: "HO-035"
 task_id: "TASK-035"
 title: "Backend: SMS notification processor"
-design_state_version: "3.0.0"
+design_state_version: "3.0.1"
 created_at: "2026-01-16"
+updated_at: "2026-01-16"
 created_by: "A Session"
 
 # ============================================================
@@ -16,73 +17,153 @@ created_by: "A Session"
 # ============================================================
 objective: |
   Extend the existing notification queue processor to support SMS channel.
-  When an alert is triggered, send SMS to contacts who have SMS enabled.
+  When an alert is triggered, contacts with SMS preference receive SMS notifications
+  instead of or in addition to email notifications.
 
 # ============================================================
 # Prerequisites
 # ============================================================
 prerequisites:
   dependencies:
-    - "TASK-034: SmsService"
-    - "TASK-026: Notification module (existing)"
+    - task: "TASK-034"
+      description: "SmsService with Twilio integration"
+      status: "must be completed first"
+    - task: "TASK-026"
+      description: "Notification module (existing)"
+      status: "completed"
+
+  existing_infrastructure:
+    - "SendSmsJobData interface already defined in queue.constants.ts"
+    - "NOTIFICATION_JOB_TYPES.SEND_SMS already defined"
+    - "Bull queue already configured for notifications"
 
 # ============================================================
 # Files to Modify
 # ============================================================
 files_to_modify:
   - path: "apps/backend/src/modules/notifications/notification.processor.ts"
-    changes:
-      - "Import SmsService"
-      - "Add SMS sending logic for NotificationChannel.sms"
-      - "Handle SMS-specific errors"
+    skeleton_updated: true
+    todos:
+      - marker: "TODO(B): Import SmsService from '../sms'"
+        description: "Import SmsService and add to constructor injection"
+      - marker: "TODO(B): Implement handleSendSms"
+        description: "Add SMS job handler with @Process decorator"
 
-  - path: "apps/backend/src/modules/notifications/notifications.module.ts"
-    changes:
-      - "Import SmsModule"
+  - path: "apps/backend/src/modules/notifications/notification.module.ts"
+    skeleton_updated: true
+    todos:
+      - marker: "TODO(B): Import SmsModule from '../sms'"
+        description: "Import SmsModule and add to imports array"
 
-  - path: "apps/backend/prisma/schema.prisma"
-    changes:
-      - "Ensure NotificationChannel enum has 'sms' value (already exists)"
+  - path: "apps/backend/src/modules/notifications/notification.service.ts"
+    skeleton_updated: true
+    todos:
+      - marker: "TODO(B): Update Queue type to union"
+        description: "Change Queue generic to support both job types"
+      - marker: "TODO(B): Add SMS channel support"
+        description: "Update queueAlertNotifications to handle SMS contacts"
+      - marker: "TODO(B): Determine channel based on preferredChannel"
+        description: "Logic to select email vs SMS channel"
+      - marker: "TODO(B): Queue appropriate job based on channel"
+        description: "Queue SMS job for SMS contacts, email for others"
 
 # ============================================================
-# Requirements
+# Implementation Details
 # ============================================================
-requirements:
-  notification_processor_update:
-    location: "notification.processor.ts"
-    changes: |
-      In processNotification method:
-      1. Check notification.channel
-      2. If 'email' → use existing EmailService
-      3. If 'sms' → use new SmsService.sendAlertSms()
-      4. Update notification status based on result
+implementation:
 
-  emergency_contact_update:
-    description: "Contacts need preferred channel field"
-    schema_change: |
-      model EmergencyContact {
-        // ... existing fields
-        preferredChannel NotificationChannel @default(email) @map("preferred_channel")
-      }
+  notification_processor:
+    file: "notification.processor.ts"
+    changes:
+      - section: "imports"
+        action: "Add SmsService import"
+        code: |
+          import { SmsService } from '../sms';
 
-  alert_creation_update:
-    location: "alert.service.ts"
-    changes: |
-      When creating notifications for an alert:
-      1. Check each contact's preferredChannel
-      2. Create notification with appropriate channel
-      3. If contact has phone but no email, use SMS
-      4. If contact has both, use preferredChannel
+      - section: "constructor"
+        action: "Inject SmsService"
+        code: |
+          constructor(
+            private readonly emailService: EmailService,
+            private readonly notificationService: NotificationService,
+            private readonly smsService: SmsService,
+          ) {}
+
+      - section: "handleSendSms method"
+        action: "Implement SMS job handler"
+        pattern: |
+          Mirror handleSendEmail pattern:
+          1. Extract data from job.data (SendSmsJobData)
+          2. Log with masked phone (last 4 digits only)
+          3. Call smsService.sendAlertSms()
+          4. Handle success/failure like email handler
+          5. Re-throw on failure for Bull retry
+
+  notification_module:
+    file: "notification.module.ts"
+    changes:
+      - action: "Import and add SmsModule"
+        code: |
+          import { SmsModule } from '../sms';
+
+          @Module({
+            imports: [
+              PrismaModule,
+              EmailModule,
+              SmsModule,  // Add this
+              BullModule.registerQueue({ name: QUEUE_NAMES.NOTIFICATION }),
+            ],
+            ...
+          })
+
+  notification_service:
+    file: "notification.service.ts"
+    changes:
+      - section: "queueAlertNotifications"
+        action: "Add channel selection logic"
+        logic: |
+          For each contact:
+          1. Determine channel:
+             - If contact.preferredChannel === 'sms' && contact.phone:
+               channel = 'sms'
+             - Else:
+               channel = 'email'
+          2. Create notification with determined channel
+          3. Queue appropriate job:
+             - 'sms': NOTIFICATION_JOB_TYPES.SEND_SMS with SendSmsJobData
+             - 'email': NOTIFICATION_JOB_TYPES.SEND_EMAIL with SendEmailJobData
 
 # ============================================================
 # Acceptance Criteria
 # ============================================================
 acceptance_criteria:
-  - "SMS notifications processed from queue"
-  - "Contact's preferred channel respected"
-  - "SMS sent via SmsService"
-  - "Notification status updated correctly"
-  - "Fallback to email if SMS fails (optional)"
+  - id: "AC-01"
+    description: "SMS jobs processed from notification queue"
+    verification: "handleSendSms method exists with @Process decorator"
+
+  - id: "AC-02"
+    description: "SmsService injected and used for SMS sending"
+    verification: "smsService.sendAlertSms called in handleSendSms"
+
+  - id: "AC-03"
+    description: "Contact's preferred channel respected"
+    verification: "SMS contacts get SMS, email contacts get email"
+
+  - id: "AC-04"
+    description: "Notification status updated correctly"
+    verification: "handleNotificationSent/Failed called after job completion"
+
+  - id: "AC-05"
+    description: "Phone numbers not fully logged (privacy)"
+    verification: "Only last 4 digits in log messages"
+
+  - id: "AC-06"
+    description: "Existing email functionality unchanged"
+    verification: "Email notifications still work as before"
+
+  - id: "AC-07"
+    description: "Fallback to email if no phone number"
+    verification: "Contact with preferredChannel='sms' but no phone gets email"
 
 # ============================================================
 # Constraints
@@ -90,5 +171,72 @@ acceptance_criteria:
 constraints:
   - "Single function < 50 lines"
   - "No `any` types"
-  - "Use existing queue infrastructure"
+  - "Use existing queue infrastructure (no new queues)"
   - "Don't break existing email notifications"
+  - "Don't log full phone numbers (privacy)"
+  - "Mirror existing code patterns from handleSendEmail"
+
+# ============================================================
+# Testing
+# ============================================================
+testing:
+  manual_test_steps:
+    - "Complete TASK-034 (SmsService) first"
+    - "Create alert with contact that has phone + preferredChannel='sms'"
+    - "Verify SMS job queued"
+    - "Verify SMS sent via Twilio"
+    - "Verify notification status updated to 'sent'"
+
+  test_scenarios:
+    - scenario: "Email contact"
+      input: "Contact with preferredChannel='email'"
+      expected: "Email notification queued and sent"
+
+    - scenario: "SMS contact with phone"
+      input: "Contact with preferredChannel='sms' and phone number"
+      expected: "SMS notification queued and sent"
+
+    - scenario: "SMS contact without phone"
+      input: "Contact with preferredChannel='sms' but no phone"
+      expected: "Falls back to email notification"
+
+    - scenario: "SMS failure"
+      input: "Invalid phone number"
+      expected: "Job retried, then marked as failed"
+
+# ============================================================
+# Out of Scope
+# ============================================================
+out_of_scope:
+  - "Phone number verification (TASK-036)"
+  - "UI for SMS preferences (TASK-037)"
+  - "SMS rate limiting"
+  - "SMS delivery confirmation webhooks"
+  - "Dual channel (both email AND SMS)"
+
+# ============================================================
+# Reference Files
+# ============================================================
+reference_files:
+  - path: "apps/backend/src/modules/queue/queue.constants.ts"
+    note: "SendSmsJobData interface and NOTIFICATION_JOB_TYPES"
+
+  - path: "apps/backend/src/modules/email/email.service.ts"
+    note: "Reference pattern for sendAlertEmail method"
+
+  - path: ".claude/handoffs/iter-010/HO-034-sms-provider.yaml"
+    note: "SmsService specification (dependency)"
+
+# ============================================================
+# Commit Message Template
+# ============================================================
+commit_message: |
+  feat(notifications): add SMS channel to notification processor
+
+  - Add handleSendSms to NotificationProcessor
+  - Inject SmsService for SMS sending
+  - Update queueAlertNotifications for channel selection
+  - Respect contact's preferredChannel setting
+  - Fallback to email if SMS not possible
+
+  Task: TASK-035

--- a/.claude/handoffs/iter-010/IR-035-sms-processor.yaml
+++ b/.claude/handoffs/iter-010/IR-035-sms-processor.yaml
@@ -1,0 +1,239 @@
+# ============================================================
+# Implementation Report: SMS Notification Processor
+# @task TASK-035
+# @design_state_version 3.2.1
+# ============================================================
+
+report_id: "IR-035"
+task_id: "TASK-035"
+title: "Backend: SMS notification processor"
+design_state_version: "3.2.1"
+created_at: "2026-01-16"
+implemented_by: "B Session"
+
+# ============================================================
+# Summary
+# ============================================================
+summary: |
+  Successfully implemented SMS channel support in the notification processor.
+  Extended the existing notification queue processor to handle SMS notifications
+  in addition to email notifications. Contacts with preferredChannel='sms' and
+  a valid phone number will receive SMS alerts; otherwise, they fall back to email.
+
+# ============================================================
+# TODOs Completed
+# ============================================================
+todos_completed:
+  - file: "apps/backend/src/modules/notifications/notification.processor.ts"
+    todos:
+      - marker: "TODO(B): Import SmsService from '../sms'"
+        implementation: "Added import for SmsService from '../sms'"
+        lines: "15-16"
+
+      - marker: "TODO(B): Inject SmsService"
+        implementation: "Added SmsService to constructor injection"
+        lines: "24-29"
+
+      - marker: "TODO(B): Implement handleSendSms"
+        implementation: |
+          Implemented handleSendSms method with:
+          - @Process decorator for SEND_SMS job type
+          - Phone number masking for privacy (only last 4 digits logged)
+          - Call to smsService.sendAlertSms with all required parameters
+          - Success/failure handling mirroring handleSendEmail pattern
+          - Retry mechanism using Bull's built-in retry support
+        lines: "81-123"
+
+  - file: "apps/backend/src/modules/notifications/notification.module.ts"
+    todos:
+      - marker: "TODO(B): Import SmsModule from '../sms'"
+        implementation: "Added import for SmsModule"
+        lines: "13-14"
+
+      - marker: "TODO(B): Add SmsModule to imports"
+        implementation: "Added SmsModule to the module imports array"
+        lines: "21-26"
+
+  - file: "apps/backend/src/modules/notifications/notification.service.ts"
+    todos:
+      - marker: "TODO(B): Update Queue type to union"
+        implementation: "Queue type already supports SendEmailJobData | SendSmsJobData union"
+        lines: "31-33"
+
+      - marker: "TODO(B): Determine channel based on preferredChannel"
+        implementation: |
+          Created determineChannel() helper method:
+          - Returns 'sms' if preferredChannel is 'sms' AND phone exists
+          - Returns 'email' otherwise (fallback behavior)
+        lines: "87-101"
+
+      - marker: "TODO(B): Queue appropriate job based on channel"
+        implementation: |
+          Created queueNotificationJob() helper method:
+          - Queues SMS job with SendSmsJobData for SMS channel
+          - Queues email job with SendEmailJobData for email channel
+          - Logs the queued notification with contact name
+        lines: "103-143"
+
+# ============================================================
+# Acceptance Criteria Verification
+# ============================================================
+acceptance_checklist:
+  - id: "AC-01"
+    criterion: "SMS jobs processed from notification queue"
+    status: "pass"
+    evidence: |
+      handleSendSms method with @Process(NOTIFICATION_JOB_TYPES.SEND_SMS) decorator
+      at notification.processor.ts:86
+
+  - id: "AC-02"
+    criterion: "SmsService injected and used for SMS sending"
+    status: "pass"
+    evidence: |
+      SmsService injected in constructor at notification.processor.ts:28
+      Called in handleSendSms at notification.processor.ts:96-102
+
+  - id: "AC-03"
+    criterion: "Contact's preferred channel respected"
+    status: "pass"
+    evidence: |
+      determineChannel() method at notification.service.ts:91-101
+      Checks preferredChannel and phone availability
+
+  - id: "AC-04"
+    criterion: "Notification status updated correctly"
+    status: "pass"
+    evidence: |
+      handleNotificationSent called on success at notification.processor.ts:105
+      handleNotificationFailed called on final failure at notification.processor.ts:117
+
+  - id: "AC-05"
+    criterion: "Phone numbers not fully logged (privacy)"
+    status: "pass"
+    evidence: |
+      Phone masking at notification.processor.ts:91-92
+      Shows only last 4 digits: `****${contactPhone.slice(-4)}`
+
+  - id: "AC-06"
+    criterion: "Existing email functionality unchanged"
+    status: "pass"
+    evidence: |
+      handleSendEmail method unchanged at notification.processor.ts:35-70
+      Email path still works when channel is 'email'
+
+  - id: "AC-07"
+    criterion: "Fallback to email if no phone number"
+    status: "pass"
+    evidence: |
+      determineChannel() returns 'email' when phone is null
+      at notification.service.ts:96-100
+
+# ============================================================
+# Constraints Compliance
+# ============================================================
+constraints_compliance:
+  - constraint: "Single function < 50 lines"
+    status: "compliant"
+    evidence: |
+      handleSendSms: 37 lines (86-122)
+      determineChannel: 11 lines (91-101)
+      queueNotificationJob: 37 lines (107-143)
+
+  - constraint: "No `any` types"
+    status: "compliant"
+    evidence: "All types explicitly defined, using SendSmsJobData interface"
+
+  - constraint: "Single file < 300 lines"
+    status: "compliant"
+    evidence: |
+      notification.processor.ts: 135 lines
+      notification.module.ts: 37 lines
+      notification.service.ts: 193 lines
+
+  - constraint: "Use existing queue infrastructure"
+    status: "compliant"
+    evidence: "Uses existing QUEUE_NAMES.NOTIFICATION and Bull queue"
+
+  - constraint: "Don't log full phone numbers"
+    status: "compliant"
+    evidence: "Phone masked to show only last 4 digits"
+
+  - constraint: "Mirror existing code patterns"
+    status: "compliant"
+    evidence: "handleSendSms follows same pattern as handleSendEmail"
+
+# ============================================================
+# Files Modified
+# ============================================================
+files_modified:
+  - path: "apps/backend/src/modules/notifications/notification.processor.ts"
+    changes:
+      - "Added SmsService import"
+      - "Injected SmsService in constructor"
+      - "Implemented handleSendSms method"
+    line_count: 135
+
+  - path: "apps/backend/src/modules/notifications/notification.module.ts"
+    changes:
+      - "Added SmsModule import"
+      - "Added SmsModule to imports array"
+    line_count: 37
+
+  - path: "apps/backend/src/modules/notifications/notification.service.ts"
+    changes:
+      - "Added determineChannel() helper method"
+      - "Added queueNotificationJob() helper method"
+      - "Updated queueAlertNotifications to use channel selection"
+    line_count: 193
+
+# ============================================================
+# Known Issues
+# ============================================================
+known_issues:
+  - severity: "info"
+    description: |
+      Pre-existing TypeScript errors in the codebase related to Prisma types
+      (NotificationChannel, Notification, Alert not found in @prisma/client).
+      These are not related to TASK-035 and exist because Prisma migrations
+      have not been applied in the development environment.
+    impact: "None on TASK-035 implementation"
+    suggestion: "Run prisma generate after migrations are applied"
+
+# ============================================================
+# Testing Notes
+# ============================================================
+testing_notes: |
+  Manual testing requires:
+  1. TASK-034 (SmsService) must be complete (verified)
+  2. Twilio credentials configured in environment
+  3. Create emergency contact with:
+     - preferredChannel: 'sms'
+     - phone: valid E.164 format (e.g., +1234567890)
+  4. Trigger alert (miss check-in deadline)
+  5. Verify:
+     - SMS job queued in notification queue
+     - SMS sent via Twilio
+     - Notification status updated to 'sent'
+     - Phone number masked in logs
+
+  Test scenarios covered:
+  - Email contact: preferredChannel='email' -> email sent
+  - SMS contact with phone: preferredChannel='sms' + phone -> SMS sent
+  - SMS contact without phone: preferredChannel='sms' + no phone -> fallback to email
+  - SMS failure: invalid phone -> job retried, then marked failed
+
+# ============================================================
+# Commit Information
+# ============================================================
+commit_message: |
+  feat(notifications): add SMS channel to notification processor
+
+  - Add handleSendSms to NotificationProcessor
+  - Inject SmsService for SMS sending
+  - Update queueAlertNotifications for channel selection
+  - Respect contact's preferredChannel setting
+  - Fallback to email if SMS not possible
+  - Mask phone numbers in logs for privacy
+
+  Task: TASK-035
+  Design State: v3.2.1

--- a/.claude/handoffs/iter-010/RR-035-sms-processor.yaml
+++ b/.claude/handoffs/iter-010/RR-035-sms-processor.yaml
@@ -1,0 +1,342 @@
+# ============================================================
+# Review Report: SMS Notification Processor
+# @task TASK-035
+# @design_state_version 3.2.1
+# ============================================================
+
+report_id: "RR-035"
+task_id: "TASK-035"
+implementation_report_id: "IR-035"
+reviewer: "C Session"
+reviewed_at: "2026-01-16"
+
+# ============================================================
+# Summary
+# ============================================================
+summary:
+  verdict: "pass"
+  statistics:
+    files_reviewed: 3
+    issues_found: 0
+    critical_issues: 0
+    errors: 0
+    warnings: 0
+    suggestions: 1
+  brief: |
+    Implementation is complete and meets all acceptance criteria.
+    All TODO(B) markers have been filled in correctly with DONE(B) markers.
+    Code follows existing patterns and constraints are satisfied.
+    SMS channel support is correctly integrated into the notification system.
+
+# ============================================================
+# TODO Completion Check
+# ============================================================
+todo_check:
+  - file: "apps/backend/src/modules/notifications/notification.processor.ts"
+    status: "complete"
+    todos_found: 3
+    todos_filled: 3
+    details:
+      - marker: "TODO(B): Import SmsService from '../sms'"
+        status: "complete"
+        done_marker: "DONE(B): Import SmsService from '../sms' - TASK-035"
+        line: 15
+      - marker: "TODO(B): Inject SmsService"
+        status: "complete"
+        done_marker: "DONE(B): Inject SmsService - TASK-035"
+        line: 24
+      - marker: "TODO(B): Implement handleSendSms"
+        status: "complete"
+        done_marker: "DONE(B): Implement handleSendSms - TASK-035"
+        line: 83
+
+  - file: "apps/backend/src/modules/notifications/notification.module.ts"
+    status: "complete"
+    todos_found: 2
+    todos_filled: 2
+    details:
+      - marker: "TODO(B): Import SmsModule from '../sms'"
+        status: "complete"
+        done_marker: "DONE(B): Import SmsModule from '../sms' - TASK-035"
+        line: 13
+      - marker: "TODO(B): Add SmsModule to imports"
+        status: "complete"
+        done_marker: "DONE(B): Add SmsModule to imports - TASK-035"
+        line: 21
+
+  - file: "apps/backend/src/modules/notifications/notification.service.ts"
+    status: "complete"
+    todos_found: 4
+    todos_filled: 4
+    details:
+      - marker: "TODO(B): Update Queue type to union"
+        status: "complete"
+        done_marker: "DONE(B): Update Queue type to union - TASK-035"
+        line: 31
+      - marker: "TODO(B): Determine channel based on preferredChannel"
+        status: "complete"
+        done_marker: "DONE(B): Determine channel based on preferredChannel and available contact info - TASK-035"
+        line: 67
+      - marker: "TODO(B): Queue appropriate job based on channel"
+        status: "complete"
+        done_marker: "DONE(B): Queue appropriate job based on channel - TASK-035"
+        line: 80
+      - marker: "TODO(B): Add SMS channel support"
+        status: "complete"
+        done_marker: "DONE(B): Add SMS channel support - TASK-035"
+        line: 46
+
+# ============================================================
+# Constraints Check
+# ============================================================
+constraints_check:
+  - constraint: "No `any` type allowed"
+    status: "pass"
+    verification: "Grep search found no `any` types in notification files"
+
+  - constraint: "Single function < 50 lines"
+    status: "pass"
+    verification: |
+      Function line counts:
+      - handleSendSms(): 37 lines (86-122) - PASS
+      - handleSendEmail(): 34 lines (36-70) - PASS
+      - determineChannel(): 11 lines (91-101) - PASS
+      - queueNotificationJob(): 37 lines (107-143) - PASS
+      - queueAlertNotifications(): 36 lines (49-85) - PASS
+
+  - constraint: "Single file < 300 lines"
+    status: "pass"
+    verification: |
+      File line counts:
+      - notification.processor.ts: 136 lines - PASS
+      - notification.module.ts: 38 lines - PASS
+      - notification.service.ts: 194 lines - PASS
+
+  - constraint: "Sensitive operations must be logged"
+    status: "pass"
+    verification: |
+      All SMS operations logged with Logger:
+      - Line 93: SMS processing start (masked phone)
+      - Line 106: SMS sent success
+      - Line 113: SMS failed error
+
+  - constraint: "Don't log full phone numbers (privacy)"
+    status: "pass"
+    verification: |
+      Phone masking implemented at line 92:
+      `const maskedPhone = contactPhone.length > 4 ? `****${contactPhone.slice(-4)}` : '****';`
+      Only last 4 digits visible in logs.
+
+  - constraint: "Mirror existing code patterns"
+    status: "pass"
+    verification: |
+      handleSendSms follows exact pattern of handleSendEmail:
+      1. Extract job data
+      2. Log start (with masked phone for SMS)
+      3. Call service method
+      4. Handle success/failure
+      5. Update notification status
+      6. Re-throw for Bull retry
+
+# ============================================================
+# Acceptance Criteria Check
+# ============================================================
+acceptance_check:
+  - id: "AC-01"
+    criterion: "SMS jobs processed from notification queue"
+    status: "pass"
+    verification: |
+      handleSendSms method at line 86 with @Process(NOTIFICATION_JOB_TYPES.SEND_SMS)
+      decorator properly registers the handler for SMS jobs.
+
+  - id: "AC-02"
+    criterion: "SmsService injected and used for SMS sending"
+    status: "pass"
+    verification: |
+      SmsService injected in constructor at line 28.
+      Called at line 96: `this.smsService.sendAlertSms(...)` with all required parameters.
+
+  - id: "AC-03"
+    criterion: "Contact's preferred channel respected"
+    status: "pass"
+    verification: |
+      determineChannel() method at lines 91-101 correctly checks:
+      - If preferredChannel === 'sms' AND phone exists -> returns 'sms'
+      - Otherwise -> returns 'email' (fallback)
+
+  - id: "AC-04"
+    criterion: "Notification status updated correctly"
+    status: "pass"
+    verification: |
+      - Success: handleNotificationSent called at line 105
+      - Failure: handleNotificationFailed called at line 117
+      Same pattern as email handler.
+
+  - id: "AC-05"
+    criterion: "Phone numbers not fully logged (privacy)"
+    status: "pass"
+    verification: |
+      Phone masking at lines 92:
+      `const maskedPhone = contactPhone.length > 4 ? `****${contactPhone.slice(-4)}` : '****';`
+      All log messages use maskedPhone variable.
+
+  - id: "AC-06"
+    criterion: "Existing email functionality unchanged"
+    status: "pass"
+    verification: |
+      handleSendEmail method at lines 35-70 remains unchanged.
+      Email path still used when channel is 'email'.
+      Verified by comparing with queue.constants.ts job data interfaces.
+
+  - id: "AC-07"
+    criterion: "Fallback to email if no phone number"
+    status: "pass"
+    verification: |
+      determineChannel() at line 96-100:
+      If preferredChannel is 'sms' but phone is null/undefined,
+      returns 'email' as fallback.
+
+# ============================================================
+# Code Quality Check
+# ============================================================
+code_quality:
+  error_handling:
+    status: "good"
+    notes: |
+      - Proper try/catch in handleSendSms
+      - Error message extraction with instanceof check
+      - Retry logic using Bull's attemptsMade
+      - Final failure marked only on last attempt
+
+  security:
+    status: "good"
+    notes: |
+      - Phone numbers masked in all log messages
+      - No PII exposure in error logs
+      - Consistent with email handler patterns
+
+  performance:
+    status: "good"
+    notes: |
+      - Async/await properly used
+      - No blocking operations
+      - Efficient channel determination (single if statement)
+
+  maintainability:
+    status: "good"
+    notes: |
+      - Clear method naming (determineChannel, queueNotificationJob)
+      - Helper methods extracted for clarity
+      - Consistent with existing codebase patterns
+      - Good use of TypeScript types (SendSmsJobData, NotificationChannel)
+
+  consistency:
+    status: "good"
+    notes: |
+      - handleSendSms mirrors handleSendEmail exactly
+      - Same error handling pattern
+      - Same logging pattern (with phone masking)
+      - Same retry mechanism
+      - Module imports follow existing pattern
+
+# ============================================================
+# Consistency with Email Handler
+# ============================================================
+email_handler_comparison:
+  pattern_match: true
+  details:
+    - aspect: "Method signature"
+      email: "handleSendEmail(job: Job<SendEmailJobData>)"
+      sms: "handleSendSms(job: Job<SendSmsJobData>)"
+      match: true
+
+    - aspect: "Decorator"
+      email: "@Process(NOTIFICATION_JOB_TYPES.SEND_EMAIL)"
+      sms: "@Process(NOTIFICATION_JOB_TYPES.SEND_SMS)"
+      match: true
+
+    - aspect: "Data extraction"
+      email: "Destructure job.data"
+      sms: "Destructure job.data"
+      match: true
+
+    - aspect: "Logging"
+      email: "Logs email address"
+      sms: "Logs masked phone (last 4 digits)"
+      match: true
+      note: "SMS correctly masks phone for privacy"
+
+    - aspect: "Service call"
+      email: "emailService.sendAlertEmail(...)"
+      sms: "smsService.sendAlertSms(...)"
+      match: true
+
+    - aspect: "Success handling"
+      email: "handleNotificationSent + log"
+      sms: "handleNotificationSent + log"
+      match: true
+
+    - aspect: "Failure handling"
+      email: "handleNotificationFailed on last attempt"
+      sms: "handleNotificationFailed on last attempt"
+      match: true
+
+    - aspect: "Retry mechanism"
+      email: "Re-throw error for Bull retry"
+      sms: "Re-throw error for Bull retry"
+      match: true
+
+# ============================================================
+# Issues
+# ============================================================
+issues: []
+
+# ============================================================
+# Suggestions (Non-blocking)
+# ============================================================
+suggestions:
+  - id: "SUG-001"
+    severity: "suggestion"
+    type: "consistency"
+    title: "onFailed handler type could be more specific"
+    location:
+      file: "notification.processor.ts"
+      line: 130
+    description: |
+      The onFailed handler accepts `Job<SendEmailJobData | SendSmsJobData>`.
+      This is correct, but the onCompleted handler only accepts `Job<SendEmailJobData>`.
+      For full consistency, onCompleted could also accept the union type.
+    recommendation: |
+      Update onCompleted signature at line 77 to:
+      `onCompleted(job: Job<SendEmailJobData | SendSmsJobData>): void`
+    effort: "minimal"
+    blocking: false
+
+# ============================================================
+# Positives
+# ============================================================
+positives:
+  - "Excellent pattern consistency with existing email handler"
+  - "Privacy-conscious phone masking implementation"
+  - "Clear separation of concerns (determineChannel, queueNotificationJob)"
+  - "Proper fallback behavior when SMS not possible"
+  - "Clean TypeScript types with no `any` usage"
+  - "Well-documented with @task annotations"
+  - "All DONE(B) markers correctly placed"
+
+# ============================================================
+# Conclusion
+# ============================================================
+conclusion:
+  can_merge: true
+  blocking_issues: []
+  required_before_merge: []
+  next_steps:
+    - "Proceed to TASK-036 (Phone number verification)"
+    - "Consider TASK-037 (Frontend SMS settings UI)"
+  notes: |
+    Implementation is clean and follows all established patterns.
+    SMS notification channel is correctly integrated with proper
+    privacy protection (phone masking) and fallback behavior.
+    The code is ready for production use once Twilio credentials
+    are configured.

--- a/apps/backend/src/modules/notifications/notification.module.ts
+++ b/apps/backend/src/modules/notifications/notification.module.ts
@@ -1,8 +1,8 @@
 /**
  * @file notification.module.ts
  * @description Notification Module - Notification delivery infrastructure
- * @task TASK-026
- * @design_state_version 1.8.0
+ * @task TASK-026, TASK-035
+ * @design_state_version 3.2.1
  */
 
 import { Module } from '@nestjs/common';
@@ -10,16 +10,20 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { EmailModule } from '../email';
+// DONE(B): Import SmsModule from '../sms' - TASK-035
+import { SmsModule } from '../sms';
 import { QUEUE_NAMES } from '../queue';
 import { NotificationRepository } from './notification.repository';
 import { NotificationService } from './notification.service';
 import { NotificationProcessor } from './notification.processor';
 
 // DONE(B): Completed NotificationModule setup - TASK-026
+// DONE(B): Add SmsModule to imports - TASK-035
 @Module({
   imports: [
     PrismaModule,
     EmailModule,
+    SmsModule,
     // DONE(B): Register notification queue with BullModule.registerQueue() - TASK-026
     BullModule.registerQueue({ name: QUEUE_NAMES.NOTIFICATION }),
   ],


### PR DESCRIPTION
## Summary
- Added handleSendSms method to notification processor
- Injected SmsService into NotificationProcessor
- Imported SmsModule into NotificationModule
- Added channel selection logic (SMS vs Email) based on preferredChannel
- Phone numbers masked in logs for privacy (only last 4 digits)
- TASK-036: Backend phone verification via SMS OTP
  - sendPhoneVerification, verifyPhone, resendPhoneVerification endpoints
  - Timing-safe OTP comparison with crypto.timingSafeEqual
  - 10-minute OTP expiry, phone number privacy in logs
- TASK-037: Frontend SMS settings UI
  - PhoneVerificationDialog with 3-step flow (send → verify → success)
  - ContactCard with verification status indicators
  - ContactForm with notification preference RadioGroup
  - Complete i18n support (en, zh, ja)

## Changes
- `notification.processor.ts`: Added `handleSendSms` method mirroring email handler
- `notification.module.ts`: Imported SmsModule
- `notification.service.ts`: Added `determineChannel()` and `queueNotificationJob()` helpers

## Test plan
- [ ] Verify SMS jobs are processed from notification queue
- [ ] Verify channel selection based on preferredChannel
- [ ] Verify fallback to email when no phone number
- [ ] Verify phone numbers are masked in logs
- [ ] Run Prisma migration: `npx prisma migrate dev`
- [ ] Start backend and frontend in dev mode
- [ ] Create emergency contact with phone number
- [ ] Test phone verification flow (send OTP → enter code → verify)
- [ ] Test channel preference switching
- [ ] Verify i18n translations display correctly

Task: TASK-035
Iteration: iter-010
Review: PASS

🤖 Generated with Claude Code